### PR TITLE
Implement trampoline method and refactor WinFsp specific code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ Version = $(shell sed -n '/^VERSION=/s/VERSION=\(.*\)/\1/p' cygfuse.cygport)
 IncDir = ./inc/fuse
 Debug = -g
 
-cygfuse-$(Version).dll libfuse-$(Version).dll.a fuse.pc: cygfuse.c fuse.pc.in
-	gcc $(Debug) -shared -o cygfuse-$(Version).dll -Wl,--out-implib=libfuse-$(Version).dll.a -I$(IncDir) cygfuse.c
+cygfuse-$(Version).dll libfuse-$(Version).dll.a fuse.pc: cygfuse.c cygfuse-winfsp.c cygfuse-dokany.c fuse.pc.in
+	gcc $(Debug) -shared -o cygfuse-$(Version).dll -Wl,--out-implib=libfuse-$(Version).dll.a -I$(IncDir) cygfuse.c cygfuse-winfsp.c cygfuse-dokany.c
 	sed "s/@Version@/$(Version)/g" fuse.pc.in > fuse.pc
 
 cygfuse-test: cygfuse-test.c cygfuse-$(Version).dll libfuse-$(Version).dll.a

--- a/cygfuse-dokany.c
+++ b/cygfuse-dokany.c
@@ -1,5 +1,5 @@
 /**
- * @file cygfuse/cygfuse.c
+ * @file cygfuse/cygfuse-dokany.c
  *
  * @copyright 2015-2016 Bill Zissimopoulos
  */
@@ -36,50 +36,9 @@
  * Modified 2016 by Mark Geisert, designated cygfuse maintainer.
  */
 
-#include <pthread.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
 #include "cygfuse-internal.h"
 
-static pthread_mutex_t cygfuse_mutex = PTHREAD_MUTEX_INITIALIZER;
-static void *cygfuse_handle = 0;
-static char *fuse_variant = NULL;
-
-/* Add short names of supported FUSE implementations here. */
-#define WINFSP  "WinFSP"
-#define DOKANY  "Dokany"
-
-void cygfuse_init(int force)
+void *cygfuse_init_dokany()
 {
-    fuse_variant = getenv("CYGFUSE");
-
-    if (!fuse_variant)
-    {
-        fprintf(stderr, "cygfuse: environment variable CYGFUSE is not set\n");
-        exit(1);
-    }
-
-    pthread_mutex_lock(&cygfuse_mutex);
-    if (force || 0 == cygfuse_handle)
-    {
-        /* Add call to additional FUSE implementation initializers here. */
-        if (0 == strncasecmp(fuse_variant, WINFSP, strlen(WINFSP)))
-            cygfuse_handle = cygfuse_init_winfsp();
-        else if (0 == strncasecmp(fuse_variant, DOKANY, strlen(DOKANY)))
-            cygfuse_handle = cygfuse_init_dokany();
-
-        if (0 == cygfuse_handle)
-            cygfuse_init_fail();
-    }
-    pthread_mutex_unlock(&cygfuse_mutex);
-}
-
-void *cygfuse_init_fail()
-{
-    fprintf(stderr, "cygfuse: %s FUSE DLL initialization failed.\n",
-            fuse_variant);
-    exit(1);
-    return 0;
+    return 0; /* Replace this with legitimate code. */
 }

--- a/cygfuse-dokany.c
+++ b/cygfuse-dokany.c
@@ -38,7 +38,7 @@
 
 #include "cygfuse-internal.h"
 
-void *cygfuse_init_dokany()
+void *cygfuse_dokany_init()
 {
     return 0; /* Replace this with legitimate code. */
 }

--- a/cygfuse-internal.h
+++ b/cygfuse-internal.h
@@ -36,6 +36,10 @@
  * Modified 2016 by Mark Geisert, designated cygfuse maintainer.
  */
 
+#include <fuse_common.h>
+#include <fuse.h>
+#include <fuse_opt.h>
+
 /* Add short names of supported FUSE implementations here. */
 #define WINFSP                          "WinFSP"
 #define DOKANY                          "Dokany"

--- a/cygfuse-internal.h
+++ b/cygfuse-internal.h
@@ -41,8 +41,8 @@
 #define DOKANY                          "Dokany"
 
 /* Add FUSE implementation initializers here. */
-void *cygfuse_init_winfsp();
-void *cygfuse_init_dokany();
+void *cygfuse_winfsp_init();
+void *cygfuse_dokany_init();
 
 void cygfuse_init(int force);
 void cygfuse_fail(const char *fmt, ...);

--- a/cygfuse-internal.h
+++ b/cygfuse-internal.h
@@ -36,9 +36,13 @@
  * Modified 2016 by Mark Geisert, designated cygfuse maintainer.
  */
 
-void cygfuse_init(int force);
-void *cygfuse_init_fail();
+/* Add short names of supported FUSE implementations here. */
+#define WINFSP                          "WinFSP"
+#define DOKANY                          "Dokany"
 
 /* Add FUSE implementation initializers here. */
 void *cygfuse_init_winfsp();
 void *cygfuse_init_dokany();
+
+void cygfuse_init(int force);
+void cygfuse_fail(const char *fmt, ...);

--- a/cygfuse-internal.h
+++ b/cygfuse-internal.h
@@ -1,5 +1,5 @@
 /**
- * @file cygfuse/cygfuse.c
+ * @file cygfuse/cygfuse-internal.h
  *
  * @copyright 2015-2016 Bill Zissimopoulos
  */
@@ -36,50 +36,9 @@
  * Modified 2016 by Mark Geisert, designated cygfuse maintainer.
  */
 
-#include <pthread.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+void cygfuse_init(int force);
+void *cygfuse_init_fail();
 
-#include "cygfuse-internal.h"
-
-static pthread_mutex_t cygfuse_mutex = PTHREAD_MUTEX_INITIALIZER;
-static void *cygfuse_handle = 0;
-static char *fuse_variant = NULL;
-
-/* Add short names of supported FUSE implementations here. */
-#define WINFSP  "WinFSP"
-#define DOKANY  "Dokany"
-
-void cygfuse_init(int force)
-{
-    fuse_variant = getenv("CYGFUSE");
-
-    if (!fuse_variant)
-    {
-        fprintf(stderr, "cygfuse: environment variable CYGFUSE is not set\n");
-        exit(1);
-    }
-
-    pthread_mutex_lock(&cygfuse_mutex);
-    if (force || 0 == cygfuse_handle)
-    {
-        /* Add call to additional FUSE implementation initializers here. */
-        if (0 == strncasecmp(fuse_variant, WINFSP, strlen(WINFSP)))
-            cygfuse_handle = cygfuse_init_winfsp();
-        else if (0 == strncasecmp(fuse_variant, DOKANY, strlen(DOKANY)))
-            cygfuse_handle = cygfuse_init_dokany();
-
-        if (0 == cygfuse_handle)
-            cygfuse_init_fail();
-    }
-    pthread_mutex_unlock(&cygfuse_mutex);
-}
-
-void *cygfuse_init_fail()
-{
-    fprintf(stderr, "cygfuse: %s FUSE DLL initialization failed.\n",
-            fuse_variant);
-    exit(1);
-    return 0;
-}
+/* Add FUSE implementation initializers here. */
+void *cygfuse_init_winfsp();
+void *cygfuse_init_dokany();

--- a/cygfuse-winfsp.c
+++ b/cygfuse-winfsp.c
@@ -37,7 +37,9 @@
  */
 
 #include <dlfcn.h>
+#include <errno.h>
 #include <fcntl.h>
+#include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/cygfuse-winfsp.c
+++ b/cygfuse-winfsp.c
@@ -45,16 +45,105 @@
 
 #include "cygfuse-internal.h"
 
+static int fsp_fuse_daemonize(int foreground);
+static int fsp_fuse_set_signal_handlers_impl(void *se);
+
+#define FSP_FUSE_ENV_INIT               \
+    {                                   \
+        'C',                            \
+        malloc, free,                   \
+        fsp_fuse_daemonize,             \
+        fsp_fuse_set_signal_handlers_impl,\
+    }
+struct fsp_fuse_env
+{
+    unsigned environment;
+    void *(*memalloc)(size_t);
+    void (*memfree)(void *);
+    int (*daemonize)(int);
+    int (*set_signal_handlers)(void *);
+    void (*reserved[4])();
+};
+static struct fsp_fuse_env fsp_fuse_env = FSP_FUSE_ENV_INIT;
+
 #define REMOVE_PARENS(...)              __VA_ARGS__
 #define CYGFUSE_API_IMPL_DEF(RET, API, PARAMS, ...)\
     static RET fsp_ ## API PARAMS __VA_ARGS__\
     extern RET (*pfn_ ## API) PARAMS;
 #define CYGFUSE_API_IMPL(RET, API, PARAMS, ARGS)\
     static RET (*pfn_fsp_ ## API) (struct fsp_fuse_env *env, REMOVE_PARENS PARAMS);\
-    CYGFUSE_API_IMPL_DEF(RET, API, PARAMS, { return pfn_fsp_ ## API (fsp_fuse_env(), REMOVE_PARENS ARGS); })
+    CYGFUSE_API_IMPL_DEF(RET, API, PARAMS, { return pfn_fsp_ ## API (&fsp_fuse_env, REMOVE_PARENS ARGS); })
 #define CYGFUSE_API_IMPL_VOID(RET, API)\
     static RET (*pfn_fsp_ ## API) (struct fsp_fuse_env *env);\
-    CYGFUSE_API_IMPL_DEF(RET, API, (void), { return pfn_fsp_ ## API (fsp_fuse_env()); })
+    CYGFUSE_API_IMPL_DEF(RET, API, (void), { return pfn_fsp_ ## API (&fsp_fuse_env); })
+
+static void (*pfn_fsp_fuse_signal_handler)(int sig);
+static void *fsp_fuse_signal_thread(void *psigmask)
+{
+    int sig;
+
+    if (0 == sigwait((sigset_t *)psigmask, &sig))
+        pfn_fsp_fuse_signal_handler(sig);
+
+    return 0;
+}
+
+static int fsp_fuse_set_signal_handlers_impl(void *se)
+{
+#define FSP_FUSE_SET_SIGNAL_HANDLER(sig, newha)\
+    if (-1 != sigaction((sig), 0, &oldsa) &&\
+        oldsa.sa_handler == (se ? SIG_DFL : (newha)))\
+    {\
+        newsa.sa_handler = se ? (newha) : SIG_DFL;\
+        sigaction((sig), &newsa, 0);\
+    }
+#define FSP_FUSE_SIGADDSET(sig)\
+    if (-1 != sigaction((sig), 0, &oldsa) &&\
+        oldsa.sa_handler == SIG_DFL)\
+        sigaddset(&sigmask, (sig));
+
+    static sigset_t sigmask;
+    static pthread_t sigthr;
+    struct sigaction oldsa, newsa = { 0 };
+
+    if (0 != se)
+    {
+        if (0 == sigthr)
+        {
+            FSP_FUSE_SET_SIGNAL_HANDLER(SIGPIPE, SIG_IGN);
+
+            sigemptyset(&sigmask);
+            FSP_FUSE_SIGADDSET(SIGHUP);
+            FSP_FUSE_SIGADDSET(SIGINT);
+            FSP_FUSE_SIGADDSET(SIGTERM);
+            if (0 != pthread_sigmask(SIG_BLOCK, &sigmask, 0))
+                return -1;
+
+            if (0 != pthread_create(&sigthr, 0, fsp_fuse_signal_thread, &sigmask))
+                return -1;
+        }
+    }
+    else
+    {
+        if (0 != sigthr)
+        {
+            pthread_cancel(sigthr);
+            pthread_join(sigthr, 0);
+            sigthr = 0;
+
+            if (0 != pthread_sigmask(SIG_UNBLOCK, &sigmask, 0))
+                return -1;
+            sigemptyset(&sigmask);
+
+            FSP_FUSE_SET_SIGNAL_HANDLER(SIGPIPE, SIG_IGN);
+        }
+    }
+
+    return 0;
+
+#undef FSP_FUSE_SIGADDSET
+#undef FSP_FUSE_SET_SIGNAL_HANDLER
+}
 
 /* fuse_common.h */
 CYGFUSE_API_IMPL_VOID(int, fuse_version)
@@ -71,6 +160,50 @@ CYGFUSE_API_IMPL(int, fuse_parse_cmdline,
 CYGFUSE_API_IMPL_DEF(void, fuse_pollhandle_destroy,
     (struct fuse_pollhandle *ph),
     {})
+CYGFUSE_API_IMPL_DEF(int, fuse_daemonize,
+    (int foreground),
+    {
+        if (!foreground)
+        {
+            if (-1 == daemon(0, 0))
+                return -1;
+
+            /*
+             * Unfortunately Cygwin fork is very fragile and cannot even correctly
+             * handle dlopen'ed DLL's if they are native (rather than Cygwin ones).
+             * [MG:] Cygwin doesn't expect non-Cygwin DLLs to be present.  That's
+             * likely a design choice but could arguably be considered a bug.  A fix
+             * would depend on the bug being reported to the main mailing list.
+             *
+             * So we have this very nasty hack where we reset the dlopen'ed handle
+             * immediately after daemonization. This will force cygfuse_init() to
+             * reload the WinFsp DLL and reset all API pointers in the daemonized
+             * process.
+             * [MG:] pthread_atfork() could be used for child reinitialization after
+             * fork().  No pthreads need be involved to use this API.  This is how
+             * Cygwin apps deal with the situation.
+             * [BZ:] not sure what happens with multiple threads here. Pthread_atfork
+             * may be a better solution for this reason alone.
+             */
+
+            /* force reload of FUSE implementation DLL to workaround fork() problems */
+            cygfuse_init(1);
+        }
+        else
+            chdir("/");
+
+        return 0;
+    })
+CYGFUSE_API_IMPL_DEF(int, fuse_set_signal_handlers,
+    (struct fuse_session *se),
+    {
+        return fsp_fuse_set_signal_handlers_impl(se);
+    })
+CYGFUSE_API_IMPL_DEF(void, fuse_remove_signal_handlers,
+    (struct fuse_session *se),
+    {
+        fsp_fuse_set_signal_handlers_impl(0);
+    })
 
 /* fuse.h */
 CYGFUSE_API_IMPL(int, fuse_main_real,
@@ -148,43 +281,11 @@ CYGFUSE_API_IMPL(int, fuse_opt_match,
         return 0;\
     else\
         pfn_ ## n = fsp_ ## n
+#define CYGFUSE_API_GET_DL(h, n)        \
+    if (0 == (*(void **)&(pfn_fsp_ ## n) = dlsym(h, "fsp_" #n)))\
+        return 0;
 #define CYGFUSE_API_GET_NS(n)           \
     pfn_ ## n = fsp_ ## n
-
-#if 0
-/*
- * Unfortunately Cygwin fork is very fragile and cannot even correctly
- * handle dlopen'ed DLL's if they are native (rather than Cygwin ones).
- * [MG:] Cygwin doesn't expect non-Cygwin DLLs to be present.  That's
- * likely a design choice but could arguably be considered a bug.  A fix
- * would depend on the bug being reported to the main mailing list.
- *
- * So we have this very nasty hack where we reset the dlopen'ed handle
- * immediately after daemonization. This will force cygfuse_init() to
- * reload the WinFsp DLL and reset all API pointers in the daemonized
- * process.
- * [MG:] pthread_atfork() could be used for child reinitialization after
- * fork().  No pthreads need be involved to use this API.  This is how
- * Cygwin apps deal with the situation.
- */
-static inline int cygfuse_daemon(int nochdir, int noclose)
-{
-    if (-1 == daemon(nochdir, noclose))
-        return -1;
-
-    /* force reload of FUSE implementation DLL to workaround fork() problems */
-    cygfuse_init(1);
-
-    return 0;
-}
-#define daemon                          cygfuse_daemon
-
-#define FSP_FUSE_API                    static
-#define FSP_FUSE_API_NAME(api)          (* pfn_ ## api)
-#define FSP_FUSE_API_CALL(api)          (cygfuse_init(0), pfn_ ## api)
-#define FSP_FUSE_SYM(proto, ...)        \
-    __attribute__ ((visibility("default"))) proto { __VA_ARGS__ }
-#endif
 
 void *cygfuse_winfsp_init()
 {
@@ -223,8 +324,8 @@ void *cygfuse_winfsp_init()
             return 0;
     }
 
-    /* winfsp_fuse.h */
-    //CYGFUSE_API_GET(h, fsp_fuse_signal_handler);
+    /* originally in winfsp_fuse.h */
+    CYGFUSE_API_GET_DL(h, fuse_signal_handler);
 
     /* fuse_common.h */
     CYGFUSE_API_GET(h, fuse_version);
@@ -232,6 +333,9 @@ void *cygfuse_winfsp_init()
     CYGFUSE_API_GET(h, fuse_unmount);
     CYGFUSE_API_GET(h, fuse_parse_cmdline);
     CYGFUSE_API_GET_NS(fuse_pollhandle_destroy);
+    CYGFUSE_API_GET_NS(fuse_daemonize);
+    CYGFUSE_API_GET_NS(fuse_set_signal_handlers);
+    CYGFUSE_API_GET_NS(fuse_remove_signal_handlers);
 
     /* fuse.h */
     CYGFUSE_API_GET(h, fuse_main_real);

--- a/cygfuse-winfsp.c
+++ b/cygfuse-winfsp.c
@@ -36,12 +36,12 @@
  * Modified 2016 by Mark Geisert, designated cygfuse maintainer.
  */
 
-#include "cygfuse-internal.h"
-
 #include <dlfcn.h>
 #include <string.h>
 #include <unistd.h>
 #include <sys/cygwin.h>
+
+#include "cygfuse-internal.h"
 
 /*
  * Unfortunately Cygwin fork is very fragile and cannot even correctly
@@ -88,7 +88,7 @@ static inline int cygfuse_daemon(int nochdir, int noclose)
 #define CYGFUSE_WINFSP_PATH             "bin\\" CYGFUSE_WINFSP_NAME
 #define CYGFUSE_GET_API(h, n)           \
     if (0 == (*(void **)&(pfn_ ## n) = dlsym(h, #n)))\
-        return cygfuse_init_fail();
+        return 0;
 
 void *cygfuse_init_winfsp()
 {
@@ -103,13 +103,13 @@ void *cygfuse_init_winfsp()
         regfd = open("/proc/registry32/HKEY_LOCAL_MACHINE"
                      "/Software/WinFsp/InstallDir", O_RDONLY);
         if (-1 == regfd)
-            return cygfuse_init_fail();
+            return 0;
 
         bytes = read(regfd, winpath,
                      sizeof winpath - sizeof CYGFUSE_WINFSP_PATH);
         close(regfd);
         if (-1 == bytes || 0 == bytes)
-            return cygfuse_init_fail();
+            return 0;
 
         if ('\0' == winpath[bytes - 1])
             bytes--;
@@ -119,12 +119,12 @@ void *cygfuse_init_winfsp()
         psxpath = (char *)
             cygwin_create_path(CCP_WIN_A_TO_POSIX | CCP_PROC_CYGDRIVE, winpath);
         if (0 == psxpath)
-            return cygfuse_init_fail();
+            return 0;
 
         h = dlopen(psxpath, RTLD_NOW);
         free(psxpath);
         if (0 == h)
-            return cygfuse_init_fail();
+            return 0;
     }
 
     /* winfsp_fuse.h */

--- a/cygfuse-winfsp.c
+++ b/cygfuse-winfsp.c
@@ -56,6 +56,22 @@
     static RET (*pfn_fsp_ ## API) (struct fsp_fuse_env *env);\
     CYGFUSE_API_IMPL_DEF(RET, API, (void), { return pfn_fsp_ ## API (fsp_fuse_env()); })
 
+/* fuse_common.h */
+CYGFUSE_API_IMPL_VOID(int, fuse_version)
+CYGFUSE_API_IMPL(struct fuse_chan *, fuse_mount,
+    (const char *mountpoint, struct fuse_args *args),
+    (mountpoint, args))
+CYGFUSE_API_IMPL(void, fuse_unmount,
+    (const char *mountpoint, struct fuse_chan *ch),
+    (mountpoint, ch))
+CYGFUSE_API_IMPL(int, fuse_parse_cmdline,
+    (struct fuse_args *args,
+        char **mountpoint, int *multithreaded, int *foreground),
+    (args, mountpoint, multithreaded, foreground))
+CYGFUSE_API_IMPL_DEF(void, fuse_pollhandle_destroy,
+    (struct fuse_pollhandle *ph),
+    {})
+
 /* fuse.h */
 CYGFUSE_API_IMPL(int, fuse_main_real,
     (int argc, char *argv[], const struct fuse_operations *ops, size_t opsize, void *data),
@@ -107,9 +123,9 @@ CYGFUSE_API_IMPL_DEF(struct fuse_session *, fuse_get_session,
     if (0 == (*(void **)&(pfn_fsp_ ## n) = dlsym(h, "fsp_" #n)))\
         return 0;\
     else\
-        pfn_ ## n = fsp_ ## n;
+        pfn_ ## n = fsp_ ## n
 #define CYGFUSE_API_GET_NS(n)           \
-    pfn_ ## n = fsp_ ## n;
+    pfn_ ## n = fsp_ ## n
 
 #if 0
 /*
@@ -187,11 +203,11 @@ void *cygfuse_winfsp_init()
     //CYGFUSE_API_GET(h, fsp_fuse_signal_handler);
 
     /* fuse_common.h */
-    //CYGFUSE_API_GET(h, fsp_fuse_version);
-    //CYGFUSE_API_GET(h, fsp_fuse_mount);
-    //CYGFUSE_API_GET(h, fsp_fuse_unmount);
-    //CYGFUSE_API_GET(h, fsp_fuse_parse_cmdline);
-    //CYGFUSE_API_GET(h, fsp_fuse_ntstatus_from_errno);
+    CYGFUSE_API_GET(h, fuse_version);
+    CYGFUSE_API_GET(h, fuse_mount);
+    CYGFUSE_API_GET(h, fuse_unmount);
+    CYGFUSE_API_GET(h, fuse_parse_cmdline);
+    CYGFUSE_API_GET_NS(fuse_pollhandle_destroy);
 
     /* fuse.h */
     CYGFUSE_API_GET(h, fuse_main_real);

--- a/cygfuse-winfsp.c
+++ b/cygfuse-winfsp.c
@@ -90,7 +90,7 @@ static inline int cygfuse_daemon(int nochdir, int noclose)
     if (0 == (*(void **)&(pfn_ ## n) = dlsym(h, #n)))\
         return 0;
 
-void *cygfuse_init_winfsp()
+void *cygfuse_winfsp_init()
 {
     void *h;
 

--- a/cygfuse-winfsp.c
+++ b/cygfuse-winfsp.c
@@ -79,6 +79,7 @@
 #define FSP_FUSE_API_INIT_NOSYM(n)\
     pfn_ ## n = fsp_ ## n
 
+
 /*
  * The WinFsp-FUSE environment.
  *

--- a/cygfuse-winfsp.c
+++ b/cygfuse-winfsp.c
@@ -66,17 +66,6 @@ struct fsp_fuse_env
 };
 static struct fsp_fuse_env fsp_fuse_env = FSP_FUSE_ENV_INIT;
 
-#define REMOVE_PARENS(...)              __VA_ARGS__
-#define CYGFUSE_API_IMPL_DEF(RET, API, PARAMS, ...)\
-    static RET fsp_ ## API PARAMS __VA_ARGS__\
-    extern RET (*pfn_ ## API) PARAMS;
-#define CYGFUSE_API_IMPL(RET, API, PARAMS, ARGS)\
-    static RET (*pfn_fsp_ ## API) (struct fsp_fuse_env *env, REMOVE_PARENS PARAMS);\
-    CYGFUSE_API_IMPL_DEF(RET, API, PARAMS, { return pfn_fsp_ ## API (&fsp_fuse_env, REMOVE_PARENS ARGS); })
-#define CYGFUSE_API_IMPL_VOID(RET, API)\
-    static RET (*pfn_fsp_ ## API) (struct fsp_fuse_env *env);\
-    CYGFUSE_API_IMPL_DEF(RET, API, (void), { return pfn_fsp_ ## API (&fsp_fuse_env); })
-
 static void (*pfn_fsp_fuse_signal_handler)(int sig);
 static void *fsp_fuse_signal_thread(void *psigmask)
 {
@@ -145,22 +134,33 @@ static int fsp_fuse_set_signal_handlers_impl(void *se)
 #undef FSP_FUSE_SET_SIGNAL_HANDLER
 }
 
+#define REMOVE_PARENS(...)              __VA_ARGS__
+#define FSP_FUSE_API_IMPL_DEF(RET, API, PARAMS, ...)\
+    static RET fsp_ ## API PARAMS __VA_ARGS__\
+    extern RET (*pfn_ ## API) PARAMS;
+#define FSP_FUSE_API_IMPL(RET, API, PARAMS, ARGS)\
+    static RET (*pfn_fsp_ ## API) (struct fsp_fuse_env *env, REMOVE_PARENS PARAMS);\
+    FSP_FUSE_API_IMPL_DEF(RET, API, PARAMS, { return pfn_fsp_ ## API (&fsp_fuse_env, REMOVE_PARENS ARGS); })
+#define FSP_FUSE_API_IMPL_VOID(RET, API)\
+    static RET (*pfn_fsp_ ## API) (struct fsp_fuse_env *env);\
+    FSP_FUSE_API_IMPL_DEF(RET, API, (void), { return pfn_fsp_ ## API (&fsp_fuse_env); })
+
 /* fuse_common.h */
-CYGFUSE_API_IMPL_VOID(int, fuse_version)
-CYGFUSE_API_IMPL(struct fuse_chan *, fuse_mount,
+FSP_FUSE_API_IMPL_VOID(int, fuse_version)
+FSP_FUSE_API_IMPL(struct fuse_chan *, fuse_mount,
     (const char *mountpoint, struct fuse_args *args),
     (mountpoint, args))
-CYGFUSE_API_IMPL(void, fuse_unmount,
+FSP_FUSE_API_IMPL(void, fuse_unmount,
     (const char *mountpoint, struct fuse_chan *ch),
     (mountpoint, ch))
-CYGFUSE_API_IMPL(int, fuse_parse_cmdline,
+FSP_FUSE_API_IMPL(int, fuse_parse_cmdline,
     (struct fuse_args *args,
         char **mountpoint, int *multithreaded, int *foreground),
     (args, mountpoint, multithreaded, foreground))
-CYGFUSE_API_IMPL_DEF(void, fuse_pollhandle_destroy,
+FSP_FUSE_API_IMPL_DEF(void, fuse_pollhandle_destroy,
     (struct fuse_pollhandle *ph),
     {})
-CYGFUSE_API_IMPL_DEF(int, fuse_daemonize,
+FSP_FUSE_API_IMPL_DEF(int, fuse_daemonize,
     (int foreground),
     {
         if (!foreground)
@@ -194,104 +194,104 @@ CYGFUSE_API_IMPL_DEF(int, fuse_daemonize,
 
         return 0;
     })
-CYGFUSE_API_IMPL_DEF(int, fuse_set_signal_handlers,
+FSP_FUSE_API_IMPL_DEF(int, fuse_set_signal_handlers,
     (struct fuse_session *se),
     {
         return fsp_fuse_set_signal_handlers_impl(se);
     })
-CYGFUSE_API_IMPL_DEF(void, fuse_remove_signal_handlers,
+FSP_FUSE_API_IMPL_DEF(void, fuse_remove_signal_handlers,
     (struct fuse_session *se),
     {
         fsp_fuse_set_signal_handlers_impl(0);
     })
 
 /* fuse.h */
-CYGFUSE_API_IMPL(int, fuse_main_real,
+FSP_FUSE_API_IMPL(int, fuse_main_real,
     (int argc, char *argv[], const struct fuse_operations *ops, size_t opsize, void *data),
     (argc, argv, ops, opsize, data))
-CYGFUSE_API_IMPL(int, fuse_is_lib_option,
+FSP_FUSE_API_IMPL(int, fuse_is_lib_option,
     (const char *opt),
     (opt))
-CYGFUSE_API_IMPL(struct fuse *, fuse_new,
+FSP_FUSE_API_IMPL(struct fuse *, fuse_new,
     (struct fuse_chan *ch, struct fuse_args *args,
         const struct fuse_operations *ops, size_t opsize, void *data),
     (ch, args, ops, opsize, data))
-CYGFUSE_API_IMPL(void, fuse_destroy,
+FSP_FUSE_API_IMPL(void, fuse_destroy,
     (struct fuse *f),
     (f))
-CYGFUSE_API_IMPL(int, fuse_loop,
+FSP_FUSE_API_IMPL(int, fuse_loop,
     (struct fuse *f),
     (f))
-CYGFUSE_API_IMPL(int, fuse_loop_mt,
+FSP_FUSE_API_IMPL(int, fuse_loop_mt,
     (struct fuse *f),
     (f))
-CYGFUSE_API_IMPL(void, fuse_exit,
+FSP_FUSE_API_IMPL(void, fuse_exit,
     (struct fuse *f),
     (f))
-CYGFUSE_API_IMPL_VOID(struct fuse_context *, fuse_get_context)
-CYGFUSE_API_IMPL_DEF(int, fuse_getgroups,
+FSP_FUSE_API_IMPL_VOID(struct fuse_context *, fuse_get_context)
+FSP_FUSE_API_IMPL_DEF(int, fuse_getgroups,
     (int size, fuse_gid_t list[]),
     { return -ENOSYS; })
-CYGFUSE_API_IMPL_DEF(int, fuse_interrupted,
+FSP_FUSE_API_IMPL_DEF(int, fuse_interrupted,
     (void),
     { return 0; })
-CYGFUSE_API_IMPL_DEF(int, fuse_invalidate,
+FSP_FUSE_API_IMPL_DEF(int, fuse_invalidate,
     (struct fuse *f, const char *path),
     { return -EINVAL; })
-CYGFUSE_API_IMPL_DEF(int, fuse_notify_poll,
+FSP_FUSE_API_IMPL_DEF(int, fuse_notify_poll,
     (struct fuse_pollhandle *ph),
     { return 0; })
-CYGFUSE_API_IMPL_DEF(struct fuse_session *, fuse_get_session,
+FSP_FUSE_API_IMPL_DEF(struct fuse_session *, fuse_get_session,
     (struct fuse *f),
     { return (struct fuse_session *)f; })
 
 /* fuse_opt.h */
-CYGFUSE_API_IMPL(int, fuse_opt_parse,
+FSP_FUSE_API_IMPL(int, fuse_opt_parse,
     (struct fuse_args *args, void *data,
         const struct fuse_opt opts[], fuse_opt_proc_t proc),
     (args, data, opts, proc))
-CYGFUSE_API_IMPL(int, fuse_opt_add_arg,
+FSP_FUSE_API_IMPL(int, fuse_opt_add_arg,
     (struct fuse_args *args, const char *arg),
     (args, arg))
-CYGFUSE_API_IMPL(int, fuse_opt_insert_arg,
+FSP_FUSE_API_IMPL(int, fuse_opt_insert_arg,
     (struct fuse_args *args, int pos, const char *arg),
     (args, pos, arg))
-CYGFUSE_API_IMPL(void, fuse_opt_free_args,
+FSP_FUSE_API_IMPL(void, fuse_opt_free_args,
     (struct fuse_args *args),
     (args))
-CYGFUSE_API_IMPL(int, fuse_opt_add_opt,
+FSP_FUSE_API_IMPL(int, fuse_opt_add_opt,
     (char **opts, const char *opt),
     (opts, opt))
-CYGFUSE_API_IMPL(int, fuse_opt_add_opt_escaped,
+FSP_FUSE_API_IMPL(int, fuse_opt_add_opt_escaped,
     (char **opts, const char *opt),
     (opts, opt))
-CYGFUSE_API_IMPL(int, fuse_opt_match,
+FSP_FUSE_API_IMPL(int, fuse_opt_match,
     (const struct fuse_opt opts[], const char *opt),
     (opts, opt))
 
 #if defined(__LP64__)
-#define CYGFUSE_WINFSP_NAME             "winfsp-x64.dll"
+#define WINFSP_NAME                     "winfsp-x64.dll"
 #else
-#define CYGFUSE_WINFSP_NAME             "winfsp-x86.dll"
+#define WINFSP_NAME                     "winfsp-x86.dll"
 #endif
-#define CYGFUSE_WINFSP_PATH             "bin\\" CYGFUSE_WINFSP_NAME
+#define WINFSP_PATH                     "bin\\" WINFSP_NAME
 
-#define CYGFUSE_API_GET(h, n)           \
+#define FSP_FUSE_API_GET(h, n)\
     if (0 == (*(void **)&(pfn_fsp_ ## n) = dlsym(h, "fsp_" #n)))\
         return 0;\
     else\
         pfn_ ## n = fsp_ ## n
-#define CYGFUSE_API_GET_DL(h, n)        \
+#define FSP_FUSE_API_GET_DL(h, n)\
     if (0 == (*(void **)&(pfn_fsp_ ## n) = dlsym(h, "fsp_" #n)))\
         return 0;
-#define CYGFUSE_API_GET_NS(n)           \
+#define FSP_FUSE_API_GET_NS(n)\
     pfn_ ## n = fsp_ ## n
 
 void *cygfuse_winfsp_init()
 {
     void *h;
 
-    h = dlopen(CYGFUSE_WINFSP_NAME, RTLD_NOW);
+    h = dlopen(WINFSP_NAME, RTLD_NOW);
     if (0 == h)
     {
         char winpath[260], *psxpath;
@@ -303,7 +303,7 @@ void *cygfuse_winfsp_init()
             return 0;
 
         bytes = read(regfd, winpath,
-                     sizeof winpath - sizeof CYGFUSE_WINFSP_PATH);
+                     sizeof winpath - sizeof WINFSP_PATH);
         close(regfd);
         if (-1 == bytes || 0 == bytes)
             return 0;
@@ -311,7 +311,7 @@ void *cygfuse_winfsp_init()
         if ('\0' == winpath[bytes - 1])
             bytes--;
         memcpy(winpath + bytes,
-               CYGFUSE_WINFSP_PATH, sizeof CYGFUSE_WINFSP_PATH);
+               WINFSP_PATH, sizeof WINFSP_PATH);
 
         psxpath = (char *)
             cygwin_create_path(CCP_WIN_A_TO_POSIX | CCP_PROC_CYGDRIVE, winpath);
@@ -325,41 +325,41 @@ void *cygfuse_winfsp_init()
     }
 
     /* originally in winfsp_fuse.h */
-    CYGFUSE_API_GET_DL(h, fuse_signal_handler);
+    FSP_FUSE_API_GET_DL(h, fuse_signal_handler);
 
     /* fuse_common.h */
-    CYGFUSE_API_GET(h, fuse_version);
-    CYGFUSE_API_GET(h, fuse_mount);
-    CYGFUSE_API_GET(h, fuse_unmount);
-    CYGFUSE_API_GET(h, fuse_parse_cmdline);
-    CYGFUSE_API_GET_NS(fuse_pollhandle_destroy);
-    CYGFUSE_API_GET_NS(fuse_daemonize);
-    CYGFUSE_API_GET_NS(fuse_set_signal_handlers);
-    CYGFUSE_API_GET_NS(fuse_remove_signal_handlers);
+    FSP_FUSE_API_GET(h, fuse_version);
+    FSP_FUSE_API_GET(h, fuse_mount);
+    FSP_FUSE_API_GET(h, fuse_unmount);
+    FSP_FUSE_API_GET(h, fuse_parse_cmdline);
+    FSP_FUSE_API_GET_NS(fuse_pollhandle_destroy);
+    FSP_FUSE_API_GET_NS(fuse_daemonize);
+    FSP_FUSE_API_GET_NS(fuse_set_signal_handlers);
+    FSP_FUSE_API_GET_NS(fuse_remove_signal_handlers);
 
     /* fuse.h */
-    CYGFUSE_API_GET(h, fuse_main_real);
-    CYGFUSE_API_GET(h, fuse_is_lib_option);
-    CYGFUSE_API_GET(h, fuse_new);
-    CYGFUSE_API_GET(h, fuse_destroy);
-    CYGFUSE_API_GET(h, fuse_loop);
-    CYGFUSE_API_GET(h, fuse_loop_mt);
-    CYGFUSE_API_GET(h, fuse_exit);
-    CYGFUSE_API_GET(h, fuse_get_context);
-    CYGFUSE_API_GET_NS(fuse_getgroups);
-    CYGFUSE_API_GET_NS(fuse_interrupted);
-    CYGFUSE_API_GET_NS(fuse_invalidate);
-    CYGFUSE_API_GET_NS(fuse_notify_poll);
-    CYGFUSE_API_GET_NS(fuse_get_session);
+    FSP_FUSE_API_GET(h, fuse_main_real);
+    FSP_FUSE_API_GET(h, fuse_is_lib_option);
+    FSP_FUSE_API_GET(h, fuse_new);
+    FSP_FUSE_API_GET(h, fuse_destroy);
+    FSP_FUSE_API_GET(h, fuse_loop);
+    FSP_FUSE_API_GET(h, fuse_loop_mt);
+    FSP_FUSE_API_GET(h, fuse_exit);
+    FSP_FUSE_API_GET(h, fuse_get_context);
+    FSP_FUSE_API_GET_NS(fuse_getgroups);
+    FSP_FUSE_API_GET_NS(fuse_interrupted);
+    FSP_FUSE_API_GET_NS(fuse_invalidate);
+    FSP_FUSE_API_GET_NS(fuse_notify_poll);
+    FSP_FUSE_API_GET_NS(fuse_get_session);
 
     /* fuse_opt.h */
-    CYGFUSE_API_GET(h, fuse_opt_parse);
-    CYGFUSE_API_GET(h, fuse_opt_add_arg);
-    CYGFUSE_API_GET(h, fuse_opt_insert_arg);
-    CYGFUSE_API_GET(h, fuse_opt_free_args);
-    CYGFUSE_API_GET(h, fuse_opt_add_opt);
-    CYGFUSE_API_GET(h, fuse_opt_add_opt_escaped);
-    CYGFUSE_API_GET(h, fuse_opt_match);
+    FSP_FUSE_API_GET(h, fuse_opt_parse);
+    FSP_FUSE_API_GET(h, fuse_opt_add_arg);
+    FSP_FUSE_API_GET(h, fuse_opt_insert_arg);
+    FSP_FUSE_API_GET(h, fuse_opt_free_args);
+    FSP_FUSE_API_GET(h, fuse_opt_add_opt);
+    FSP_FUSE_API_GET(h, fuse_opt_add_opt_escaped);
+    FSP_FUSE_API_GET(h, fuse_opt_match);
 
     return h;
 }

--- a/cygfuse-winfsp.c
+++ b/cygfuse-winfsp.c
@@ -1,0 +1,160 @@
+/**
+ * @file cygfuse/cygfuse-winfsp.c
+ *
+ * @copyright 2015-2016 Bill Zissimopoulos
+ */
+/*
+ * This file was  originally part of WinFsp. It has  been relicensed by the
+ * original author under the BSD 2-clause license:
+ *
+ * Copyright (c) 2015-2016, Bill Zissimopoulos. All rights reserved.
+ *
+ * Redistribution  and use  in source  and  binary forms,  with or  without
+ * modification, are  permitted provided that the  following conditions are
+ * met:
+ *
+ * 1.  Redistributions  of source  code  must  retain the  above  copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions  in binary  form must  reproduce the  above copyright
+ * notice,  this list  of conditions  and the  following disclaimer  in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY  THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND  ANY EXPRESS OR  IMPLIED WARRANTIES, INCLUDING, BUT  NOT LIMITED
+ * TO,  THE  IMPLIED  WARRANTIES  OF  MERCHANTABILITY  AND  FITNESS  FOR  A
+ * PARTICULAR  PURPOSE ARE  DISCLAIMED.  IN NO  EVENT  SHALL THE  COPYRIGHT
+ * HOLDER OR CONTRIBUTORS  BE LIABLE FOR ANY  DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL,  EXEMPLARY,  OR  CONSEQUENTIAL   DAMAGES  (INCLUDING,  BUT  NOT
+ * LIMITED TO,  PROCUREMENT OF SUBSTITUTE  GOODS OR SERVICES; LOSS  OF USE,
+ * DATA, OR  PROFITS; OR BUSINESS  INTERRUPTION) HOWEVER CAUSED AND  ON ANY
+ * THEORY  OF LIABILITY,  WHETHER IN  CONTRACT, STRICT  LIABILITY, OR  TORT
+ * (INCLUDING NEGLIGENCE  OR OTHERWISE) ARISING IN  ANY WAY OUT OF  THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/*
+ * Modified 2016 by Mark Geisert, designated cygfuse maintainer.
+ */
+
+#include "cygfuse-internal.h"
+
+#include <dlfcn.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/cygwin.h>
+
+/*
+ * Unfortunately Cygwin fork is very fragile and cannot even correctly
+ * handle dlopen'ed DLL's if they are native (rather than Cygwin ones).
+ * [MG:] Cygwin doesn't expect non-Cygwin DLLs to be present.  That's
+ * likely a design choice but could arguably be considered a bug.  A fix
+ * would depend on the bug being reported to the main mailing list.
+ *
+ * So we have this very nasty hack where we reset the dlopen'ed handle
+ * immediately after daemonization. This will force cygfuse_init() to
+ * reload the WinFsp DLL and reset all API pointers in the daemonized
+ * process.
+ * [MG:] pthread_atfork() could be used for child reinitialization after
+ * fork().  No pthreads need be involved to use this API.  This is how
+ * Cygwin apps deal with the situation.
+ */
+static inline int cygfuse_daemon(int nochdir, int noclose)
+{
+    if (-1 == daemon(nochdir, noclose))
+        return -1;
+
+    /* force reload of FUSE implementation DLL to workaround fork() problems */
+    cygfuse_init(1);
+
+    return 0;
+}
+#define daemon                          cygfuse_daemon
+
+#define FSP_FUSE_API                    static
+#define FSP_FUSE_API_NAME(api)          (* pfn_ ## api)
+#define FSP_FUSE_API_CALL(api)          (cygfuse_init(0), pfn_ ## api)
+#define FSP_FUSE_SYM(proto, ...)        \
+    __attribute__ ((visibility("default"))) proto { __VA_ARGS__ }
+#include <fuse_common.h>
+#include <fuse.h>
+#include <fuse_opt.h>
+
+#if defined(__LP64__)
+#define CYGFUSE_WINFSP_NAME             "winfsp-x64.dll"
+#else
+#define CYGFUSE_WINFSP_NAME             "winfsp-x86.dll"
+#endif
+
+#define CYGFUSE_WINFSP_PATH             "bin\\" CYGFUSE_WINFSP_NAME
+#define CYGFUSE_GET_API(h, n)           \
+    if (0 == (*(void **)&(pfn_ ## n) = dlsym(h, #n)))\
+        return cygfuse_init_fail();
+
+void *cygfuse_init_winfsp()
+{
+    void *h;
+
+    h = dlopen(CYGFUSE_WINFSP_NAME, RTLD_NOW);
+    if (0 == h)
+    {
+        char winpath[260], *psxpath;
+        int regfd, bytes;
+
+        regfd = open("/proc/registry32/HKEY_LOCAL_MACHINE"
+                     "/Software/WinFsp/InstallDir", O_RDONLY);
+        if (-1 == regfd)
+            return cygfuse_init_fail();
+
+        bytes = read(regfd, winpath,
+                     sizeof winpath - sizeof CYGFUSE_WINFSP_PATH);
+        close(regfd);
+        if (-1 == bytes || 0 == bytes)
+            return cygfuse_init_fail();
+
+        if ('\0' == winpath[bytes - 1])
+            bytes--;
+        memcpy(winpath + bytes,
+               CYGFUSE_WINFSP_PATH, sizeof CYGFUSE_WINFSP_PATH);
+
+        psxpath = (char *)
+            cygwin_create_path(CCP_WIN_A_TO_POSIX | CCP_PROC_CYGDRIVE, winpath);
+        if (0 == psxpath)
+            return cygfuse_init_fail();
+
+        h = dlopen(psxpath, RTLD_NOW);
+        free(psxpath);
+        if (0 == h)
+            return cygfuse_init_fail();
+    }
+
+    /* winfsp_fuse.h */
+    CYGFUSE_GET_API(h, fsp_fuse_signal_handler);
+
+    /* fuse_common.h */
+    CYGFUSE_GET_API(h, fsp_fuse_version);
+    CYGFUSE_GET_API(h, fsp_fuse_mount);
+    CYGFUSE_GET_API(h, fsp_fuse_unmount);
+    CYGFUSE_GET_API(h, fsp_fuse_parse_cmdline);
+    CYGFUSE_GET_API(h, fsp_fuse_ntstatus_from_errno);
+
+    /* fuse.h */
+    CYGFUSE_GET_API(h, fsp_fuse_main_real);
+    CYGFUSE_GET_API(h, fsp_fuse_is_lib_option);
+    CYGFUSE_GET_API(h, fsp_fuse_new);
+    CYGFUSE_GET_API(h, fsp_fuse_destroy);
+    CYGFUSE_GET_API(h, fsp_fuse_loop);
+    CYGFUSE_GET_API(h, fsp_fuse_loop_mt);
+    CYGFUSE_GET_API(h, fsp_fuse_exit);
+    CYGFUSE_GET_API(h, fsp_fuse_get_context);
+
+    /* fuse_opt.h */
+    CYGFUSE_GET_API(h, fsp_fuse_opt_parse);
+    CYGFUSE_GET_API(h, fsp_fuse_opt_add_arg);
+    CYGFUSE_GET_API(h, fsp_fuse_opt_insert_arg);
+    CYGFUSE_GET_API(h, fsp_fuse_opt_free_args);
+    CYGFUSE_GET_API(h, fsp_fuse_opt_add_opt);
+    CYGFUSE_GET_API(h, fsp_fuse_opt_add_opt_escaped);
+    CYGFUSE_GET_API(h, fsp_fuse_opt_match);
+
+    return h;
+}

--- a/cygfuse-winfsp.c
+++ b/cygfuse-winfsp.c
@@ -112,6 +112,30 @@ CYGFUSE_API_IMPL_DEF(struct fuse_session *, fuse_get_session,
     (struct fuse *f),
     { return (struct fuse_session *)f; })
 
+/* fuse_opt.h */
+CYGFUSE_API_IMPL(int, fuse_opt_parse,
+    (struct fuse_args *args, void *data,
+        const struct fuse_opt opts[], fuse_opt_proc_t proc),
+    (args, data, opts, proc))
+CYGFUSE_API_IMPL(int, fuse_opt_add_arg,
+    (struct fuse_args *args, const char *arg),
+    (args, arg))
+CYGFUSE_API_IMPL(int, fuse_opt_insert_arg,
+    (struct fuse_args *args, int pos, const char *arg),
+    (args, pos, arg))
+CYGFUSE_API_IMPL(void, fuse_opt_free_args,
+    (struct fuse_args *args),
+    (args))
+CYGFUSE_API_IMPL(int, fuse_opt_add_opt,
+    (char **opts, const char *opt),
+    (opts, opt))
+CYGFUSE_API_IMPL(int, fuse_opt_add_opt_escaped,
+    (char **opts, const char *opt),
+    (opts, opt))
+CYGFUSE_API_IMPL(int, fuse_opt_match,
+    (const struct fuse_opt opts[], const char *opt),
+    (opts, opt))
+
 #if defined(__LP64__)
 #define CYGFUSE_WINFSP_NAME             "winfsp-x64.dll"
 #else
@@ -225,13 +249,13 @@ void *cygfuse_winfsp_init()
     CYGFUSE_API_GET_NS(fuse_get_session);
 
     /* fuse_opt.h */
-    //CYGFUSE_API_GET(h, fsp_fuse_opt_parse);
-    //CYGFUSE_API_GET(h, fsp_fuse_opt_add_arg);
-    //CYGFUSE_API_GET(h, fsp_fuse_opt_insert_arg);
-    //CYGFUSE_API_GET(h, fsp_fuse_opt_free_args);
-    //CYGFUSE_API_GET(h, fsp_fuse_opt_add_opt);
-    //CYGFUSE_API_GET(h, fsp_fuse_opt_add_opt_escaped);
-    //CYGFUSE_API_GET(h, fsp_fuse_opt_match);
+    CYGFUSE_API_GET(h, fuse_opt_parse);
+    CYGFUSE_API_GET(h, fuse_opt_add_arg);
+    CYGFUSE_API_GET(h, fuse_opt_insert_arg);
+    CYGFUSE_API_GET(h, fuse_opt_free_args);
+    CYGFUSE_API_GET(h, fuse_opt_add_opt);
+    CYGFUSE_API_GET(h, fuse_opt_add_opt_escaped);
+    CYGFUSE_API_GET(h, fuse_opt_match);
 
     return h;
 }

--- a/cygfuse-winfsp.c
+++ b/cygfuse-winfsp.c
@@ -278,15 +278,15 @@ FSP_FUSE_API_IMPL(int, fuse_opt_match,
 #endif
 #define WINFSP_PATH                     "bin\\" WINFSP_NAME
 
-#define FSP_FUSE_API_GET(h, n)\
+#define FSP_FUSE_API_INIT(h, n)\
     if (0 == (*(void **)&(pfn_fsp_ ## n) = dlsym(h, "fsp_" #n)))\
         return 0;\
     else\
         pfn_ ## n = fsp_ ## n
-#define FSP_FUSE_API_GET_DL(h, n)\
+#define FSP_FUSE_API_INIT_DLSYM(h, n)\
     if (0 == (*(void **)&(pfn_fsp_ ## n) = dlsym(h, "fsp_" #n)))\
         return 0;
-#define FSP_FUSE_API_GET_NS(n)\
+#define FSP_FUSE_API_INIT_NOSYM(n)\
     pfn_ ## n = fsp_ ## n
 
 void *cygfuse_winfsp_init()
@@ -327,41 +327,41 @@ void *cygfuse_winfsp_init()
     }
 
     /* originally in winfsp_fuse.h */
-    FSP_FUSE_API_GET_DL(h, fuse_signal_handler);
+    FSP_FUSE_API_INIT_DLSYM(h, fuse_signal_handler);
 
     /* fuse_common.h */
-    FSP_FUSE_API_GET(h, fuse_version);
-    FSP_FUSE_API_GET(h, fuse_mount);
-    FSP_FUSE_API_GET(h, fuse_unmount);
-    FSP_FUSE_API_GET(h, fuse_parse_cmdline);
-    FSP_FUSE_API_GET_NS(fuse_pollhandle_destroy);
-    FSP_FUSE_API_GET_NS(fuse_daemonize);
-    FSP_FUSE_API_GET_NS(fuse_set_signal_handlers);
-    FSP_FUSE_API_GET_NS(fuse_remove_signal_handlers);
+    FSP_FUSE_API_INIT(h, fuse_version);
+    FSP_FUSE_API_INIT(h, fuse_mount);
+    FSP_FUSE_API_INIT(h, fuse_unmount);
+    FSP_FUSE_API_INIT(h, fuse_parse_cmdline);
+    FSP_FUSE_API_INIT_NOSYM(fuse_pollhandle_destroy);
+    FSP_FUSE_API_INIT_NOSYM(fuse_daemonize);
+    FSP_FUSE_API_INIT_NOSYM(fuse_set_signal_handlers);
+    FSP_FUSE_API_INIT_NOSYM(fuse_remove_signal_handlers);
 
     /* fuse.h */
-    FSP_FUSE_API_GET(h, fuse_main_real);
-    FSP_FUSE_API_GET(h, fuse_is_lib_option);
-    FSP_FUSE_API_GET(h, fuse_new);
-    FSP_FUSE_API_GET(h, fuse_destroy);
-    FSP_FUSE_API_GET(h, fuse_loop);
-    FSP_FUSE_API_GET(h, fuse_loop_mt);
-    FSP_FUSE_API_GET(h, fuse_exit);
-    FSP_FUSE_API_GET(h, fuse_get_context);
-    FSP_FUSE_API_GET_NS(fuse_getgroups);
-    FSP_FUSE_API_GET_NS(fuse_interrupted);
-    FSP_FUSE_API_GET_NS(fuse_invalidate);
-    FSP_FUSE_API_GET_NS(fuse_notify_poll);
-    FSP_FUSE_API_GET_NS(fuse_get_session);
+    FSP_FUSE_API_INIT(h, fuse_main_real);
+    FSP_FUSE_API_INIT(h, fuse_is_lib_option);
+    FSP_FUSE_API_INIT(h, fuse_new);
+    FSP_FUSE_API_INIT(h, fuse_destroy);
+    FSP_FUSE_API_INIT(h, fuse_loop);
+    FSP_FUSE_API_INIT(h, fuse_loop_mt);
+    FSP_FUSE_API_INIT(h, fuse_exit);
+    FSP_FUSE_API_INIT(h, fuse_get_context);
+    FSP_FUSE_API_INIT_NOSYM(fuse_getgroups);
+    FSP_FUSE_API_INIT_NOSYM(fuse_interrupted);
+    FSP_FUSE_API_INIT_NOSYM(fuse_invalidate);
+    FSP_FUSE_API_INIT_NOSYM(fuse_notify_poll);
+    FSP_FUSE_API_INIT_NOSYM(fuse_get_session);
 
     /* fuse_opt.h */
-    FSP_FUSE_API_GET(h, fuse_opt_parse);
-    FSP_FUSE_API_GET(h, fuse_opt_add_arg);
-    FSP_FUSE_API_GET(h, fuse_opt_insert_arg);
-    FSP_FUSE_API_GET(h, fuse_opt_free_args);
-    FSP_FUSE_API_GET(h, fuse_opt_add_opt);
-    FSP_FUSE_API_GET(h, fuse_opt_add_opt_escaped);
-    FSP_FUSE_API_GET(h, fuse_opt_match);
+    FSP_FUSE_API_INIT(h, fuse_opt_parse);
+    FSP_FUSE_API_INIT(h, fuse_opt_add_arg);
+    FSP_FUSE_API_INIT(h, fuse_opt_insert_arg);
+    FSP_FUSE_API_INIT(h, fuse_opt_free_args);
+    FSP_FUSE_API_INIT(h, fuse_opt_add_opt);
+    FSP_FUSE_API_INIT(h, fuse_opt_add_opt_escaped);
+    FSP_FUSE_API_INIT(h, fuse_opt_match);
 
     return h;
 }

--- a/cygfuse.c
+++ b/cygfuse.c
@@ -178,13 +178,18 @@ static char *fuse_variant = NULL;
 
 void cygfuse_init(int force)
 {
-    fuse_variant = getenv("CYGFUSE");
-    if (!fuse_variant)
-        cygfuse_fail("cygfuse: environment variable CYGFUSE is not set\n");
-
+    /*
+     * Expensive lock is ok, because cygfuse_init calls will be eliminated
+     * soon by our "trampoline" code. This is only to protect against
+     * concurrent initialization.
+     */
     pthread_mutex_lock(&cygfuse_mutex);
     if (force || 0 == cygfuse_handle)
     {
+        fuse_variant = getenv("CYGFUSE");
+        if (!fuse_variant)
+            cygfuse_fail("cygfuse: environment variable CYGFUSE is not set\n");
+
         /* Add call to additional FUSE implementation initializers here. */
         if (0 == strncasecmp(fuse_variant, WINFSP, strlen(WINFSP)))
             cygfuse_handle = cygfuse_winfsp_init();

--- a/cygfuse.c
+++ b/cygfuse.c
@@ -110,6 +110,30 @@ CYGFUSE_API_IMPL(struct fuse_session *, fuse_get_session,
     (struct fuse *f),
     (f))
 
+/* fuse_opt.h */
+CYGFUSE_API_IMPL(int, fuse_opt_parse,
+    (struct fuse_args *args, void *data,
+        const struct fuse_opt opts[], fuse_opt_proc_t proc),
+    (args, data, opts, proc))
+CYGFUSE_API_IMPL(int, fuse_opt_add_arg,
+    (struct fuse_args *args, const char *arg),
+    (args, arg))
+CYGFUSE_API_IMPL(int, fuse_opt_insert_arg,
+    (struct fuse_args *args, int pos, const char *arg),
+    (args, pos, arg))
+CYGFUSE_API_IMPL(void, fuse_opt_free_args,
+    (struct fuse_args *args),
+    (args))
+CYGFUSE_API_IMPL(int, fuse_opt_add_opt,
+    (char **opts, const char *opt),
+    (opts, opt))
+CYGFUSE_API_IMPL(int, fuse_opt_add_opt_escaped,
+    (char **opts, const char *opt),
+    (opts, opt))
+CYGFUSE_API_IMPL(int, fuse_opt_match,
+    (const struct fuse_opt opts[], const char *opt),
+    (opts, opt))
+
 static pthread_mutex_t cygfuse_mutex = PTHREAD_MUTEX_INITIALIZER;
 static void *cygfuse_handle = 0;
 static char *fuse_variant = NULL;

--- a/cygfuse.c
+++ b/cygfuse.c
@@ -59,9 +59,9 @@ void cygfuse_init(int force)
     {
         /* Add call to additional FUSE implementation initializers here. */
         if (0 == strncasecmp(fuse_variant, WINFSP, strlen(WINFSP)))
-            cygfuse_handle = cygfuse_init_winfsp();
+            cygfuse_handle = cygfuse_winfsp_init();
         else if (0 == strncasecmp(fuse_variant, DOKANY, strlen(DOKANY)))
-            cygfuse_handle = cygfuse_init_dokany();
+            cygfuse_handle = cygfuse_dokany_init();
 
         if (0 == cygfuse_handle)
             cygfuse_fail("cygfuse: %s FUSE DLL initialization failed.\n",

--- a/cygfuse.c
+++ b/cygfuse.c
@@ -44,6 +44,54 @@
 
 #include "cygfuse-internal.h"
 
+#define CYGFUSE_API_IMPL(RET, API, PARAMS, ARGS)\
+    static RET dfl_ ## API PARAMS;\
+    RET (*pfn_ ## API) PARAMS = dfl_ ## API;\
+    static RET dfl_ ## API PARAMS { cygfuse_init(0); return pfn_ ## API ARGS; }\
+    __attribute__ ((visibility("default"))) RET API PARAMS { return pfn_ ## API ARGS; }
+
+/* fuse.h */
+CYGFUSE_API_IMPL(int, fuse_main_real,
+    (int argc, char *argv[], const struct fuse_operations *ops, size_t opsize, void *data),
+    (argc, argv, ops, opsize, data))
+CYGFUSE_API_IMPL(int, fuse_is_lib_option,
+    (const char *opt),
+    (opt))
+CYGFUSE_API_IMPL(struct fuse *, fuse_new,
+    (struct fuse_chan *ch, struct fuse_args *args,
+        const struct fuse_operations *ops, size_t opsize, void *data),
+    (ch, args, ops, opsize, data))
+CYGFUSE_API_IMPL(void, fuse_destroy,
+    (struct fuse *f),
+    (f))
+CYGFUSE_API_IMPL(int, fuse_loop,
+    (struct fuse *f),
+    (f))
+CYGFUSE_API_IMPL(int, fuse_loop_mt,
+    (struct fuse *f),
+    (f))
+CYGFUSE_API_IMPL(void, fuse_exit,
+    (struct fuse *f),
+    (f))
+CYGFUSE_API_IMPL(struct fuse_context *, fuse_get_context,
+    (void),
+    ())
+CYGFUSE_API_IMPL(int, fuse_getgroups,
+    (int size, fuse_gid_t list[]),
+    (size, list))
+CYGFUSE_API_IMPL(int, fuse_interrupted,
+    (void),
+    ())
+CYGFUSE_API_IMPL(int, fuse_invalidate,
+    (struct fuse *f, const char *path),
+    (f, path))
+CYGFUSE_API_IMPL(int, fuse_notify_poll,
+    (struct fuse_pollhandle *ph),
+    (ph))
+CYGFUSE_API_IMPL(struct fuse_session *, fuse_get_session,
+    (struct fuse *f),
+    (f))
+
 static pthread_mutex_t cygfuse_mutex = PTHREAD_MUTEX_INITIALIZER;
 static void *cygfuse_handle = 0;
 static char *fuse_variant = NULL;

--- a/cygfuse.c
+++ b/cygfuse.c
@@ -199,6 +199,8 @@ void cygfuse_init(int force)
     {
         fuse_provider = getenv("CYGFUSE");
         if (!fuse_provider)
+            //FIXME if provider existence was testable, need not fail here...
+            //FIXME for example if only one provider exists, could use it.
             cygfuse_fail("cygfuse: environment variable CYGFUSE is not set\n");
 
         for (int i = 0; i < num_providers; i++)

--- a/cygfuse.c
+++ b/cygfuse.c
@@ -67,6 +67,15 @@ CYGFUSE_API_IMPL(int, fuse_parse_cmdline,
 CYGFUSE_API_IMPL(void, fuse_pollhandle_destroy,
     (struct fuse_pollhandle *ph),
     (ph))
+CYGFUSE_API_IMPL(int, fuse_daemonize,
+    (int foreground),
+    (foreground))
+CYGFUSE_API_IMPL(int, fuse_set_signal_handlers,
+    (struct fuse_session *se),
+    (se))
+CYGFUSE_API_IMPL(void, fuse_remove_signal_handlers,
+    (struct fuse_session *se),
+    (se))
 
 /* fuse.h */
 CYGFUSE_API_IMPL(int, fuse_main_real,

--- a/cygfuse.c
+++ b/cygfuse.c
@@ -50,6 +50,24 @@
     static RET dfl_ ## API PARAMS { cygfuse_init(0); return pfn_ ## API ARGS; }\
     __attribute__ ((visibility("default"))) RET API PARAMS { return pfn_ ## API ARGS; }
 
+/* fuse_common.h */
+CYGFUSE_API_IMPL(int, fuse_version,
+    (void),
+    ())
+CYGFUSE_API_IMPL(struct fuse_chan *, fuse_mount,
+    (const char *mountpoint, struct fuse_args *args),
+    (mountpoint, args))
+CYGFUSE_API_IMPL(void, fuse_unmount,
+    (const char *mountpoint, struct fuse_chan *ch),
+    (mountpoint, ch))
+CYGFUSE_API_IMPL(int, fuse_parse_cmdline,
+    (struct fuse_args *args,
+        char **mountpoint, int *multithreaded, int *foreground),
+    (args, mountpoint, multithreaded, foreground))
+CYGFUSE_API_IMPL(void, fuse_pollhandle_destroy,
+    (struct fuse_pollhandle *ph),
+    (ph))
+
 /* fuse.h */
 CYGFUSE_API_IMPL(int, fuse_main_real,
     (int argc, char *argv[], const struct fuse_operations *ops, size_t opsize, void *data),

--- a/cygfuse.c
+++ b/cygfuse.c
@@ -210,4 +210,5 @@ void cygfuse_fail(const char *fmt, ...)
     va_start(ap, fmt);
     vfprintf(stderr, fmt, ap);
     va_end(ap);
+    exit(1);
 }

--- a/cygfuse.cygport
+++ b/cygfuse.cygport
@@ -55,7 +55,7 @@ src_install()
     doinclude fuse.h
     doinclude fuse_common.h
     doinclude fuse_opt.h
-    doinclude winfsp_fuse.h
+    doinclude cygfuse.h
 
     cd ${B}
     dobin cygfuse-${VERSION}.dll

--- a/inc/fuse/cygfuse.h
+++ b/inc/fuse/cygfuse.h
@@ -1,6 +1,5 @@
 /**
- * @file fuse/winfsp_fuse.h
- * WinFsp FUSE compatible API.
+ * @file fuse/cygfuse.h
  *
  * @copyright 2015-2016 Bill Zissimopoulos
  */
@@ -34,41 +33,22 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef FUSE_WINFSP_FUSE_H_INCLUDED
-#define FUSE_WINFSP_FUSE_H_INCLUDED
+#ifndef CYGFUSE_H_
+#define CYGFUSE_H_
 
 #include <errno.h>
 #include <stdint.h>
-#if !defined(WINFSP_DLL_INTERNAL)
 #include <stdlib.h>
-#endif
+#include <fcntl.h>
+#include <pthread.h>
+#include <signal.h>
+#include <sys/stat.h>
+#include <sys/statvfs.h>
+#include <sys/types.h>
+#include <utime.h>
 
 #ifdef __cplusplus
 extern "C" {
-#endif
-
-#if !defined(FSP_FUSE_API)
-#if defined(WINFSP_DLL_INTERNAL)
-#define FSP_FUSE_API                    __declspec(dllexport)
-#else
-#define FSP_FUSE_API                    __declspec(dllimport)
-#endif
-#endif
-
-#if !defined(FSP_FUSE_API_NAME)
-#define FSP_FUSE_API_NAME(n)            (n)
-#endif
-
-#if !defined(FSP_FUSE_API_CALL)
-#define FSP_FUSE_API_CALL(n)            (n)
-#endif
-
-#if !defined(FSP_FUSE_SYM)
-#if !defined(CYGFUSE)
-#define FSP_FUSE_SYM(proto, ...)        static inline proto { __VA_ARGS__ }
-#else
-#define FSP_FUSE_SYM(proto, ...)        proto;
-#endif
 #endif
 
 /*
@@ -82,121 +62,6 @@ extern "C" {
  * to be compatible with the equivalent Cygwin types as we want WinFsp-FUSE
  * to be usable from Cygwin.
  */
-
-#if defined(_WIN64) || defined(_WIN32)
-
-typedef uint32_t fuse_uid_t;
-typedef uint32_t fuse_gid_t;
-typedef int32_t fuse_pid_t;
-
-typedef uint32_t fuse_dev_t;
-typedef uint64_t fuse_ino_t;
-typedef uint32_t fuse_mode_t;
-typedef uint16_t fuse_nlink_t;
-typedef int64_t fuse_off_t;
-
-#if defined(_WIN64)
-typedef uint64_t fuse_fsblkcnt_t;
-typedef uint64_t fuse_fsfilcnt_t;
-#else
-typedef uint32_t fuse_fsblkcnt_t;
-typedef uint32_t fuse_fsfilcnt_t;
-#endif
-typedef int32_t fuse_blksize_t;
-typedef int64_t fuse_blkcnt_t;
-
-#if defined(_WIN64)
-struct fuse_utimbuf
-{
-    int64_t actime;
-    int64_t modtime;
-};
-struct fuse_timespec
-{
-    int64_t tv_sec;
-    int64_t tv_nsec;
-};
-#else
-struct fuse_utimbuf
-{
-    int32_t actime;
-    int32_t modtime;
-};
-struct fuse_timespec
-{
-    int32_t tv_sec;
-    int32_t tv_nsec;
-};
-#endif
-
-struct fuse_stat
-{
-    fuse_dev_t st_dev;
-    fuse_ino_t st_ino;
-    fuse_mode_t st_mode;
-    fuse_nlink_t st_nlink;
-    fuse_uid_t st_uid;
-    fuse_gid_t st_gid;
-    fuse_dev_t st_rdev;
-    fuse_off_t st_size;
-    struct fuse_timespec st_atim;
-    struct fuse_timespec st_mtim;
-    struct fuse_timespec st_ctim;
-    fuse_blksize_t st_blksize;
-    fuse_blkcnt_t st_blocks;
-    struct fuse_timespec st_birthtim;
-};
-
-#if defined(_WIN64)
-struct fuse_statvfs
-{
-    uint64_t f_bsize;
-    uint64_t f_frsize;
-    fuse_fsblkcnt_t f_blocks;
-    fuse_fsblkcnt_t f_bfree;
-    fuse_fsblkcnt_t f_bavail;
-    fuse_fsfilcnt_t f_files;
-    fuse_fsfilcnt_t f_ffree;
-    fuse_fsfilcnt_t f_favail;
-    uint64_t f_fsid;
-    uint64_t f_flag;
-    uint64_t f_namemax;
-};
-#else
-struct fuse_statvfs
-{
-    uint32_t f_bsize;
-    uint32_t f_frsize;
-    fuse_fsblkcnt_t f_blocks;
-    fuse_fsblkcnt_t f_bfree;
-    fuse_fsblkcnt_t f_bavail;
-    fuse_fsfilcnt_t f_files;
-    fuse_fsfilcnt_t f_ffree;
-    fuse_fsfilcnt_t f_favail;
-    uint32_t f_fsid;
-    uint32_t f_flag;
-    uint32_t f_namemax;
-};
-#endif
-
-struct fuse_flock
-{
-    int16_t l_type;
-    int16_t l_whence;
-    fuse_off_t l_start;
-    fuse_off_t l_len;
-    fuse_pid_t l_pid;
-};
-
-#elif defined(__CYGWIN__)
-
-#include <fcntl.h>
-#include <pthread.h>
-#include <signal.h>
-#include <sys/stat.h>
-#include <sys/statvfs.h>
-#include <sys/types.h>
-#include <utime.h>
 
 #define fuse_uid_t                      uid_t
 #define fuse_gid_t                      gid_t
@@ -224,10 +89,6 @@ struct fuse_flock
  * Note that long is 8 bytes long in Cygwin64 and 4 bytes long in Win64.
  * For this reason we avoid using long anywhere in these headers.
  */
-
-#else
-#error unsupported environment
-#endif
 
 #ifdef __cplusplus
 }

--- a/inc/fuse/cygfuse.h
+++ b/inc/fuse/cygfuse.h
@@ -36,15 +36,14 @@
 #ifndef CYGFUSE_H_
 #define CYGFUSE_H_
 
-#include <errno.h>
-#include <stdint.h>
-#include <stdlib.h>
+/* include here all headers that libfuse2.8:fuse.h,fuse_common.h include */
 #include <fcntl.h>
-#include <pthread.h>
-#include <signal.h>
+#include <stdint.h>
 #include <sys/stat.h>
 #include <sys/statvfs.h>
 #include <sys/types.h>
+#include <sys/uio.h>
+#include <time.h>
 #include <utime.h>
 
 #ifdef __cplusplus
@@ -57,10 +56,8 @@ extern "C" {
  * within the same OS. This is certainly true on Windows, where these types
  * are not even native.
  *
- * For this reason we will define our own fuse_* types which represent the
- * types as the WinFsp DLL expects to see them. We will define these types
- * to be compatible with the equivalent Cygwin types as we want WinFsp-FUSE
- * to be usable from Cygwin.
+ * For this reason we will define our own fuse_* types to be compatible with
+ * the equivalent Cygwin types.
  */
 
 #define fuse_uid_t                      uid_t

--- a/inc/fuse/fuse.h
+++ b/inc/fuse/fuse.h
@@ -120,116 +120,21 @@ struct fuse_context
 #define fuse_main(argc, argv, ops, data)\
     fuse_main_real(argc, argv, ops, sizeof *(ops), data)
 
-FSP_FUSE_API int FSP_FUSE_API_NAME(fsp_fuse_main_real)(struct fsp_fuse_env *env,
-    int argc, char *argv[],
-    const struct fuse_operations *ops, size_t opsize, void *data);
-FSP_FUSE_API int FSP_FUSE_API_NAME(fsp_fuse_is_lib_option)(struct fsp_fuse_env *env,
-    const char *opt);
-FSP_FUSE_API struct fuse *FSP_FUSE_API_NAME(fsp_fuse_new)(struct fsp_fuse_env *env,
-    struct fuse_chan *ch, struct fuse_args *args,
-    const struct fuse_operations *ops, size_t opsize, void *data);
-FSP_FUSE_API void FSP_FUSE_API_NAME(fsp_fuse_destroy)(struct fsp_fuse_env *env,
-    struct fuse *f);
-FSP_FUSE_API int FSP_FUSE_API_NAME(fsp_fuse_loop)(struct fsp_fuse_env *env,
-    struct fuse *f);
-FSP_FUSE_API int FSP_FUSE_API_NAME(fsp_fuse_loop_mt)(struct fsp_fuse_env *env,
-    struct fuse *f);
-FSP_FUSE_API void FSP_FUSE_API_NAME(fsp_fuse_exit)(struct fsp_fuse_env *env,
-    struct fuse *f);
-FSP_FUSE_API struct fuse_context *FSP_FUSE_API_NAME(fsp_fuse_get_context)(struct fsp_fuse_env *env);
-
-FSP_FUSE_SYM(
 int fuse_main_real(int argc, char *argv[],
-    const struct fuse_operations *ops, size_t opsize, void *data),
-{
-    return FSP_FUSE_API_CALL(fsp_fuse_main_real)
-        (fsp_fuse_env(), argc, argv, ops, opsize, data);
-})
-
-FSP_FUSE_SYM(
-int fuse_is_lib_option(const char *opt),
-{
-    return FSP_FUSE_API_CALL(fsp_fuse_is_lib_option)
-        (fsp_fuse_env(), opt);
-})
-
-FSP_FUSE_SYM(
+    const struct fuse_operations *ops, size_t opsize, void *data);
+int fuse_is_lib_option(const char *opt);
 struct fuse *fuse_new(struct fuse_chan *ch, struct fuse_args *args,
-    const struct fuse_operations *ops, size_t opsize, void *data),
-{
-    return FSP_FUSE_API_CALL(fsp_fuse_new)
-        (fsp_fuse_env(), ch, args, ops, opsize, data);
-})
-
-FSP_FUSE_SYM(
-void fuse_destroy(struct fuse *f),
-{
-    FSP_FUSE_API_CALL(fsp_fuse_destroy)
-        (fsp_fuse_env(), f);
-})
-
-FSP_FUSE_SYM(
-int fuse_loop(struct fuse *f),
-{
-    return FSP_FUSE_API_CALL(fsp_fuse_loop)
-        (fsp_fuse_env(), f);
-})
-
-FSP_FUSE_SYM(
-int fuse_loop_mt(struct fuse *f),
-{
-    return FSP_FUSE_API_CALL(fsp_fuse_loop_mt)
-        (fsp_fuse_env(), f);
-})
-
-FSP_FUSE_SYM(
-void fuse_exit(struct fuse *f),
-{
-    FSP_FUSE_API_CALL(fsp_fuse_exit)
-        (fsp_fuse_env(), f);
-})
-
-FSP_FUSE_SYM(
-struct fuse_context *fuse_get_context(void),
-{
-    return FSP_FUSE_API_CALL(fsp_fuse_get_context)
-        (fsp_fuse_env());
-})
-
-FSP_FUSE_SYM(
-int fuse_getgroups(int size, fuse_gid_t list[]),
-{
-    (void)size;
-    (void)list;
-    return -ENOSYS;
-})
-
-FSP_FUSE_SYM(
-int fuse_interrupted(void),
-{
-    return 0;
-})
-
-FSP_FUSE_SYM(
-int fuse_invalidate(struct fuse *f, const char *path),
-{
-    (void)f;
-    (void)path;
-    return -EINVAL;
-})
-
-FSP_FUSE_SYM(
-int fuse_notify_poll(struct fuse_pollhandle *ph),
-{
-    (void)ph;
-    return 0;
-})
-
-FSP_FUSE_SYM(
-struct fuse_session *fuse_get_session(struct fuse *f),
-{
-    return (struct fuse_session *)f;
-})
+    const struct fuse_operations *ops, size_t opsize, void *data);
+void fuse_destroy(struct fuse *f);
+int fuse_loop(struct fuse *f);
+int fuse_loop_mt(struct fuse *f);
+void fuse_exit(struct fuse *f);
+struct fuse_context *fuse_get_context(void);
+int fuse_getgroups(int size, fuse_gid_t list[]);
+int fuse_interrupted(void);
+int fuse_invalidate(struct fuse *f, const char *path);
+int fuse_notify_poll(struct fuse_pollhandle *ph);
+struct fuse_session *fuse_get_session(struct fuse *f);
 
 #ifdef __cplusplus
 }

--- a/inc/fuse/fuse.h
+++ b/inc/fuse/fuse.h
@@ -1,6 +1,5 @@
 /**
  * @file fuse/fuse.h
- * WinFsp FUSE compatible API.
  *
  * This file is derived from libfuse/include/fuse.h:
  *     FUSE: Filesystem in Userspace

--- a/inc/fuse/fuse_common.h
+++ b/inc/fuse/fuse_common.h
@@ -1,6 +1,5 @@
 /**
  * @file fuse/fuse_common.h
- * WinFsp FUSE compatible API.
  *
  * This file is derived from libfuse/include/fuse_common.h:
  *     FUSE: Filesystem in Userspace
@@ -41,7 +40,7 @@
 #ifndef FUSE_COMMON_H_
 #define FUSE_COMMON_H_
 
-#include "winfsp_fuse.h"
+#include "cygfuse.h"
 #include "fuse_opt.h"
 
 #ifdef __cplusplus

--- a/inc/fuse/fuse_common.h
+++ b/inc/fuse/fuse_common.h
@@ -95,51 +95,12 @@ struct fuse_session;
 struct fuse_chan;
 struct fuse_pollhandle;
 
-FSP_FUSE_API int FSP_FUSE_API_NAME(fsp_fuse_version)(struct fsp_fuse_env *env);
-FSP_FUSE_API struct fuse_chan *FSP_FUSE_API_NAME(fsp_fuse_mount)(struct fsp_fuse_env *env,
-    const char *mountpoint, struct fuse_args *args);
-FSP_FUSE_API void FSP_FUSE_API_NAME(fsp_fuse_unmount)(struct fsp_fuse_env *env,
-    const char *mountpoint, struct fuse_chan *ch);
-FSP_FUSE_API int FSP_FUSE_API_NAME(fsp_fuse_parse_cmdline)(struct fsp_fuse_env *env,
-    struct fuse_args *args,
-    char **mountpoint, int *multithreaded, int *foreground);
-FSP_FUSE_API int32_t FSP_FUSE_API_NAME(fsp_fuse_ntstatus_from_errno)(struct fsp_fuse_env *env,
-    int err);
-
-FSP_FUSE_SYM(
-int fuse_version(void),
-{
-    return FSP_FUSE_API_CALL(fsp_fuse_version)
-        (fsp_fuse_env());
-})
-
-FSP_FUSE_SYM(
-struct fuse_chan *fuse_mount(const char *mountpoint, struct fuse_args *args),
-{
-    return FSP_FUSE_API_CALL(fsp_fuse_mount)
-        (fsp_fuse_env(), mountpoint, args);
-})
-
-FSP_FUSE_SYM(
-void fuse_unmount(const char *mountpoint, struct fuse_chan *ch),
-{
-    FSP_FUSE_API_CALL(fsp_fuse_unmount)
-        (fsp_fuse_env(), mountpoint, ch);
-})
-
-FSP_FUSE_SYM(
+int fuse_version(void);
+struct fuse_chan *fuse_mount(const char *mountpoint, struct fuse_args *args);
+void fuse_unmount(const char *mountpoint, struct fuse_chan *ch);
 int fuse_parse_cmdline(struct fuse_args *args,
-    char **mountpoint, int *multithreaded, int *foreground),
-{
-    return FSP_FUSE_API_CALL(fsp_fuse_parse_cmdline)
-        (fsp_fuse_env(), args, mountpoint, multithreaded, foreground);
-})
-
-FSP_FUSE_SYM(
-void fuse_pollhandle_destroy(struct fuse_pollhandle *ph),
-{
-    (void)ph;
-})
+    char **mountpoint, int *multithreaded, int *foreground);
+void fuse_pollhandle_destroy(struct fuse_pollhandle *ph);
 
 FSP_FUSE_SYM(
 int fuse_daemonize(int foreground),

--- a/inc/fuse/fuse_common.h
+++ b/inc/fuse/fuse_common.h
@@ -101,25 +101,9 @@ void fuse_unmount(const char *mountpoint, struct fuse_chan *ch);
 int fuse_parse_cmdline(struct fuse_args *args,
     char **mountpoint, int *multithreaded, int *foreground);
 void fuse_pollhandle_destroy(struct fuse_pollhandle *ph);
-
-FSP_FUSE_SYM(
-int fuse_daemonize(int foreground),
-{
-    return fsp_fuse_daemonize(foreground);
-})
-
-FSP_FUSE_SYM(
-int fuse_set_signal_handlers(struct fuse_session *se),
-{
-    return fsp_fuse_set_signal_handlers(se);
-})
-
-FSP_FUSE_SYM(
-void fuse_remove_signal_handlers(struct fuse_session *se),
-{
-    (void)se;
-    fsp_fuse_set_signal_handlers(0);
-})
+int fuse_daemonize(int foreground);
+int fuse_set_signal_handlers(struct fuse_session *se);
+void fuse_remove_signal_handlers(struct fuse_session *se);
 
 #ifdef __cplusplus
 }

--- a/inc/fuse/fuse_opt.h
+++ b/inc/fuse/fuse_opt.h
@@ -1,6 +1,5 @@
 /**
  * @file fuse/fuse_opt.h
- * WinFsp FUSE compatible API.
  *
  * This file is derived from libfuse/include/fuse_opt.h:
  *     FUSE: Filesystem in Userspace

--- a/inc/fuse/fuse_opt.h
+++ b/inc/fuse/fuse_opt.h
@@ -41,8 +41,6 @@
 #ifndef FUSE_OPT_H_
 #define FUSE_OPT_H_
 
-#include "winfsp_fuse.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -74,71 +72,14 @@ struct fuse_args
 typedef int (*fuse_opt_proc_t)(void *data, const char *arg, int key,
     struct fuse_args *outargs);
 
-FSP_FUSE_API int FSP_FUSE_API_NAME(fsp_fuse_opt_parse)(struct fsp_fuse_env *env,
-    struct fuse_args *args, void *data,
-    const struct fuse_opt opts[], fuse_opt_proc_t proc);
-FSP_FUSE_API int FSP_FUSE_API_NAME(fsp_fuse_opt_add_arg)(struct fsp_fuse_env *env,
-    struct fuse_args *args, const char *arg);
-FSP_FUSE_API int FSP_FUSE_API_NAME(fsp_fuse_opt_insert_arg)(struct fsp_fuse_env *env,
-    struct fuse_args *args, int pos, const char *arg);
-FSP_FUSE_API void FSP_FUSE_API_NAME(fsp_fuse_opt_free_args)(struct fsp_fuse_env *env,
-    struct fuse_args *args);
-FSP_FUSE_API int FSP_FUSE_API_NAME(fsp_fuse_opt_add_opt)(struct fsp_fuse_env *env,
-    char **opts, const char *opt);
-FSP_FUSE_API int FSP_FUSE_API_NAME(fsp_fuse_opt_add_opt_escaped)(struct fsp_fuse_env *env,
-    char **opts, const char *opt);
-FSP_FUSE_API int FSP_FUSE_API_NAME(fsp_fuse_opt_match)(struct fsp_fuse_env *env,
-    const struct fuse_opt opts[], const char *opt);
-
-FSP_FUSE_SYM(
 int fuse_opt_parse(struct fuse_args *args, void *data,
-    const struct fuse_opt opts[], fuse_opt_proc_t proc),
-{
-    return FSP_FUSE_API_CALL(fsp_fuse_opt_parse)
-        (fsp_fuse_env(), args, data, opts, proc);
-})
-
-FSP_FUSE_SYM(
-int fuse_opt_add_arg(struct fuse_args *args, const char *arg),
-{
-    return FSP_FUSE_API_CALL(fsp_fuse_opt_add_arg)
-        (fsp_fuse_env(), args, arg);
-})
-
-FSP_FUSE_SYM(
-int fuse_opt_insert_arg(struct fuse_args *args, int pos, const char *arg),
-{
-    return FSP_FUSE_API_CALL(fsp_fuse_opt_insert_arg)
-        (fsp_fuse_env(), args, pos, arg);
-})
-
-FSP_FUSE_SYM(
-void fuse_opt_free_args(struct fuse_args *args),
-{
-    FSP_FUSE_API_CALL(fsp_fuse_opt_free_args)
-        (fsp_fuse_env(), args);
-})
-
-FSP_FUSE_SYM(
-int fuse_opt_add_opt(char **opts, const char *opt),
-{
-    return FSP_FUSE_API_CALL(fsp_fuse_opt_add_opt)
-        (fsp_fuse_env(), opts, opt);
-})
-
-FSP_FUSE_SYM(
-int fuse_opt_add_opt_escaped(char **opts, const char *opt),
-{
-    return FSP_FUSE_API_CALL(fsp_fuse_opt_add_opt_escaped)
-        (fsp_fuse_env(), opts, opt);
-})
-
-FSP_FUSE_SYM(
-int fuse_opt_match(const struct fuse_opt opts[], const char *opt),
-{
-    return FSP_FUSE_API_CALL(fsp_fuse_opt_match)
-        (fsp_fuse_env(), opts, opt);
-})
+    const struct fuse_opt opts[], fuse_opt_proc_t proc);
+int fuse_opt_add_arg(struct fuse_args *args, const char *arg);
+int fuse_opt_insert_arg(struct fuse_args *args, int pos, const char *arg);
+void fuse_opt_free_args(struct fuse_args *args);
+int fuse_opt_add_opt(char **opts, const char *opt);
+int fuse_opt_add_opt_escaped(char **opts, const char *opt);
+int fuse_opt_match(const struct fuse_opt opts[], const char *opt);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Hello, Mark. I am listening to tunes from MP3FS running on Cygwin as I type this :)

The commits in this PR include the following work:
- Implement the "trampoline" method for FUSE API implementation.
- Refactor all WinFsp specific code from the header files into a separate `cygfuse-winfsp.c` file.

Regarding the "trampoline" method the following code comment explains:

```
/*
 * FUSE API implementation.
 *
 * We use a "trampoline" idea where all FUSE API calls get forwarded to the
 * appropriate implementation through a function pointer. This function
 * pointer is set up to point to a default implementation when the program
 * first starts. The default implementation calls cygfuse_init and then goes
 * back and calls the corresponding function pointer again. The expectation
 * is that cygfuse_init has set up things properly so that the function
 * pointer now points to the real FUSE API implementation.
 *
 * Subsequent calls to a FUSE API will now see a pointer to the real FUSE API
 * implementation and will circumvent calls to cygfuse_init.
 */
```

This makes it easy for specific FUSE variants (I think you call them providers now) to provide their own implementation of FUSE API's. For example, to implement `fuse_new` they simply have to assign the proper value to `pfn_fuse_new` in their `cyfguse_VARIANT_init` function and the trampoline mechanism will do the rest.

[BTW, I am not particularly attached to (or happy with) the name "trampoline" so feel free to change it, if you like.]

Regarding the WinFsp refactoring. All WinFsp specific code now lives in `cygfuse-winfsp.c`. The file `winfsp_fuse.h` has been renamed to `cygfuse.h` and has no WinFsp specific code.

I did some other changes here and there, for example, I removed `cygfuse_init_fail` and introduced `cygfuse_fail` (which does `vfprintf` and exits). I am also seeing that this PR cannot be automatically merged anymore. My apologies but I forked your repo last night just prior to your provider related changes and did not merge those in.

I tested the new **cygfuse** with SSHFS and MP3FS. Here are instructions for SSHFS:

```
git clone https://github.com/billziss-gh/sshfs.git
cd sshfs
autoreconf -i
./configure
make
./sshfs -o idmap=user USERNAME@SERVER: S:
cd /cygdrive/s
ls -la, etc.
cd -
pkill sshfs
```

It is also possible but harder to build MP3FS because of its many dependencies and because one dependency (LAME) does not exist as a Cygwin package. You first have to build LAME by downloading from https://github.com/cygwinports-extras/lame and then you must clone MP3FS.

```
git clone https://github.com/khenriks/mp3fs.git
cd mp3fs
LAMEROOT="$PWD/../lame/root" # wherever you put LAME
./autogen.sh
CPPFLAGS=-D_GNU_SOURCE \
CFLAGS=-I$LAMEROOT/usr/include \
CXXFLAGS=-I$LAMEROOT/usr/include \
LDFLAGS=-L$LAMEROOT/usr/lib \
./configure --without-vorbis-picture
make
src/mp3fs -o FileInfoTimeout=-1 SAMPLESDIR S:
# open media player and listen to tunes :)
pkill mp3fs
```
